### PR TITLE
Fix "do" example

### DIFF
--- a/2012/09/actually-YOU-dont-understand-lexical-scope.md
+++ b/2012/09/actually-YOU-dont-understand-lexical-scope.md
@@ -193,10 +193,11 @@ for (var i=0; i<methods.length; i++) {
 And in CoffeeScript you write:
 
 ```coffeescript
-do (methods = ['remove', 'show', 'hide', 'stop']) ->
-  for method in methods then do ->
+methods = ['remove', 'show', 'hide', 'stop']
+for method in methods
+  do (method) ->
     Frame.prototype[method] = ->
-      for element in elements then do ->
+      for element in elements
         this[element][method]()
 ```
 


### PR DESCRIPTION
The first `do` in the example is redundant (and requires `methods` to be null or undefined), and the other ones don't do anything because they're not taking parameters. Instead, you need a `do (method) ->` call, analogous to the IIFE (`(function(method) { ... })(methods[i])`) in the JS code.

Here's a demo.

``` coffee
class Frame

methods = null
do (methods = ['remove', 'show', 'hide', 'stop']) ->
  for method in methods then do ->
    Frame.prototype[method] = ->
      for i in [0...1] then do ->
        console.log method

(new Frame).remove() # => stop :(


methods = ['remove', 'show', 'hide', 'stop']
for method in methods
  do (method) ->
    Frame.prototype[method] = ->
      for i in [0...1]
        console.log method

(new Frame).remove() # => remove :)
```
