### PR TITLE
Fix typos and syntax errors in this.md

### DIFF
--- a/2013/01/this.md
+++ b/2013/01/this.md
@@ -7,7 +7,7 @@ More than you ever wanted to know about "this" in JavaScript, Part I
 
 ### what is "this" and why do we need it?
 
-In JavaScript, it's easy to make things that look and behave like object without using function prototypes or "this." Here's a Queue:
+In JavaScript, it's easy to make things that look and behave like objects without using function prototypes or "this." Here's a Queue:
 
 ```javascript
 function QueueMaker () {
@@ -46,7 +46,7 @@ queue.pullHead();
 Let's make a shallow copy of our queue using Underscore's `_.extend`:
 
 ```javascript
-copyOfQueue = extend({}, queue);
+copyOfQueue = _.extend({}, queue);
 
 queue !== copyOfQueue;
   //=> true
@@ -392,13 +392,15 @@ Our `contextualize` function returns a new function that calls a function with a
 var aFourthObject = {
       uncontextualized: function () {
         return this;
+      },
+      contextualized: function(context) {
+        return contextualize(function (context) {
+            return this;
+        }, context)
       }
-      contextualized: contextualize(function () {
-        return this;
-      })
     },
     a = aFourthObject.uncontextualized,
-    b = aFourthObject.contextualized;
+    b = aFourthObject.contextualized(aFourthObject);
     
 a() === aFourthObject;
   //=> false


### PR DESCRIPTION
This fix was already merged in (in https://github.com/raganwald/homoiconic/pull/36 ), but was later accidentally clobbered by commit b2b5c4ad6069.

This pull request fixes 4 issues with this.md:
- An English typo in the second paragraph.
- A call to _.extend was missing the _. prefix.
- A syntax error in the aFourthObject example (missing comma).
- A logic error in the aFourthObject example. I had trouble determining the intent of this example, but b() === aFourthObject; did not evaluate to true as the comment indicated it should, so I changed the code so it would evaluate to true. Maybe you had a different bit of logic in mind, though, so you should fix it the way you originally intended.
