### PR TITLE
fix ruby errors in prototypes.md

### DIFF
--- a/2013/02/prototypes.md
+++ b/2013/02/prototypes.md
@@ -62,8 +62,8 @@ class Queue
   
   def pullHead
     if !@isEmpty
-      @array[@head]).tap { |value|
-        @array[@head] = null
+      @array[@head].tap { |value|
+        @array[@head] = nil
         @head += 1
       }
     end


### PR DESCRIPTION
The Queue example in ruby had a stray paren and a use of null instead of nil.

Also I'm not sure why !! is needed in Queue#isEmpty - the < operator will always return true/false. But I haven't changed that because I'm not sure.
